### PR TITLE
Extract shared AsyncStorage helpers for storage services

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,31 @@
+export const hasValue = (value?: string | null): value is string => {
+  return Boolean(value && value.trim().length > 0);
+};
+
+interface EnvOptions {
+  fallback?: string;
+  required?: boolean;
+}
+
+const getEnvVar = (key: string, options: EnvOptions = {}): string => {
+  const { fallback = "", required = true } = options;
+  const value = process.env[key];
+
+  if (hasValue(value)) {
+    return value.trim();
+  }
+
+  if (required) {
+    console.warn(`[env] 환경 변수 ${key}가 설정되지 않았습니다.`);
+  }
+
+  return fallback;
+};
+
+export const env = {
+  tmdbApiKey: getEnvVar("TMDB_API_KEY"),
+  naverClientId: getEnvVar("NAVER_CLIENT_ID", { required: false }),
+  naverClientSecret: getEnvVar("NAVER_CLIENT_SECRET", { required: false }),
+  supabaseUrl: getEnvVar("SUPABASE_URL", { required: false }),
+  supabaseKey: getEnvVar("SUPABASE_KEY", { required: false }),
+};

--- a/src/services/api/clients.ts
+++ b/src/services/api/clients.ts
@@ -1,0 +1,62 @@
+import axios, { AxiosInstance } from "axios";
+import { env, hasValue } from "../../config/env";
+
+export const PLACEHOLDER_IMAGE =
+  "https://via.placeholder.com/128x192?text=No+Cover";
+
+export const tmdbApi = axios.create({
+  baseURL: "https://api.themoviedb.org/3",
+  params: {
+    api_key: env.tmdbApiKey,
+    language: "ko-KR",
+  },
+  timeout: 10000,
+});
+
+tmdbApi.interceptors.request.use(
+  (config) => {
+    console.log(`API 요청: ${config.url}, 파라미터:`, config.params);
+    return config;
+  },
+  (error) => {
+    console.error("API 요청 오류:", error);
+    return Promise.reject(error);
+  }
+);
+
+tmdbApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    console.error(`API 응답 오류: ${error.message}`, error.config);
+    if (error.response) {
+      console.error("응답 데이터:", error.response.data);
+      console.error("응답 상태:", error.response.status);
+    }
+    return Promise.reject(error);
+  }
+);
+
+export const hasNaverBookCredentials =
+  hasValue(env.naverClientId) && hasValue(env.naverClientSecret);
+
+export const naverBookApi: AxiosInstance | null = hasNaverBookCredentials
+  ? axios.create({
+      baseURL: "https://openapi.naver.com/v1/search",
+      timeout: 10000,
+      headers: {
+        "X-Naver-Client-Id": env.naverClientId,
+        "X-Naver-Client-Secret": env.naverClientSecret,
+      },
+    })
+  : null;
+
+if (!hasNaverBookCredentials) {
+  console.warn(
+    "[api] 네이버 도서 API 자격 증명이 없어 구글 도서 API로 대체됩니다."
+  );
+}
+
+export const googleBooksApi = axios.create({
+  baseURL: "https://www.googleapis.com/books/v1",
+  timeout: 10000,
+});

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,0 +1,3 @@
+export { bookService } from "./books";
+export { movieService } from "./movies";
+export { hasNaverBookCredentials } from "./clients";

--- a/src/services/api/movies.ts
+++ b/src/services/api/movies.ts
@@ -1,0 +1,47 @@
+import { ApiResponse, Movie } from "../../types";
+import { tmdbApi } from "./clients";
+
+export const movieService = {
+  async getPopular(page = 1): Promise<ApiResponse<Movie>> {
+    try {
+      console.log(`인기 영화 요청: 페이지 ${page}`);
+      const response = await tmdbApi.get("/movie/popular", {
+        params: { page },
+      });
+
+      if (response.data.page !== page) {
+        console.warn(`페이지 불일치: 요청=${page}, 응답=${response.data.page}`);
+      }
+
+      return response.data;
+    } catch (error) {
+      console.error(`인기 영화 가져오기 오류(페이지 ${page}):`, error);
+      throw error;
+    }
+  },
+
+  async searchMovies(query: string, page = 1): Promise<ApiResponse<Movie>> {
+    const response = await tmdbApi.get("/search/movie", {
+      params: { query, page },
+    });
+
+    return response.data;
+  },
+
+  async getMovieDetails(movieId: number): Promise<Movie> {
+    const response = await tmdbApi.get(`/movie/${movieId}`);
+
+    return response.data;
+  },
+
+  async getMoviesByGenre(
+    genreId: number,
+    page = 1
+  ): Promise<ApiResponse<Movie>> {
+    const response = await tmdbApi.get("/discover/movie", {
+      params: { with_genres: genreId, page },
+    });
+
+    return response.data;
+  },
+};

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -2,9 +2,16 @@ import { createClient } from "@supabase/supabase-js";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import "react-native-url-polyfill/auto";
 
-// Supabase URL과 API 키 설정 (실제 값으로 변경 필요)
-const SUPABASE_URL = process.env.SUPABASE_URL || "";
-const SUPABASE_KEY = process.env.SUPABASE_KEY || "";
+import { env, hasValue } from "../config/env";
+
+const SUPABASE_URL = env.supabaseUrl;
+const SUPABASE_KEY = env.supabaseKey;
+
+if (!hasValue(SUPABASE_URL) || !hasValue(SUPABASE_KEY)) {
+  console.warn(
+    "[supabase] 환경 변수가 없어 실시간 기능이 제한될 수 있습니다."
+  );
+}
 
 // Supabase 클라이언트 생성
 export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {

--- a/src/utils/asyncStorage.ts
+++ b/src/utils/asyncStorage.ts
@@ -1,0 +1,61 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+type FallbackValue<T> = T | (() => T);
+
+interface JsonStorageOptions<T> {
+  fallback: FallbackValue<T>;
+  label?: string;
+}
+
+const resolveFallback = <T>(fallback: FallbackValue<T>): T => {
+  return typeof fallback === "function" ? (fallback as () => T)() : fallback;
+};
+
+export const readJsonItem = async <T>(
+  key: string,
+  options: JsonStorageOptions<T>
+): Promise<T> => {
+  const { fallback, label } = options;
+  const defaultValue = resolveFallback(fallback);
+
+  try {
+    const rawValue = await AsyncStorage.getItem(key);
+
+    if (!rawValue) {
+      return defaultValue;
+    }
+
+    return JSON.parse(rawValue) as T;
+  } catch (error) {
+    console.error(
+      `[storage] ${label ?? key} 불러오기 오류:`,
+      error
+    );
+    return defaultValue;
+  }
+};
+
+export const writeJsonItem = async <T>(
+  key: string,
+  value: T,
+  label?: string
+): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error(`[storage] ${label ?? key} 저장 오류:`, error);
+  }
+};
+
+export const updateJsonItem = async <T>(
+  key: string,
+  updater: (currentValue: T) => T,
+  options: JsonStorageOptions<T>
+): Promise<T> => {
+  const currentValue = await readJsonItem<T>(key, options);
+  const updatedValue = updater(currentValue);
+
+  await writeJsonItem(key, updatedValue, options.label);
+
+  return updatedValue;
+};


### PR DESCRIPTION
## Summary
- add reusable AsyncStorage helper utilities to centralize JSON parsing and logging
- refactor the storage service to consume the shared helpers and remove duplicate read/write flows

## Testing
- pnpm tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68db4836f43c8331a331d9ff09d8c4e1